### PR TITLE
Call pause on the created entity

### DIFF
--- a/src/lib/commands/EntityCreateCommand.js
+++ b/src/lib/commands/EntityCreateCommand.js
@@ -53,6 +53,7 @@ export class EntityCreateCommand extends Command {
     }
 
     const entity = createEntity(definition, callback, parentEl);
+    entity.pause();
     this.entityId = entity.id;
     return entity;
   }

--- a/src/lib/commands/EntityRemoveCommand.js
+++ b/src/lib/commands/EntityRemoveCommand.js
@@ -43,6 +43,7 @@ export class EntityRemoveCommand extends Command {
     this.entity.addEventListener(
       'loaded',
       () => {
+        this.entity.pause();
         Events.emit('entitycreated', this.entity);
         this.editor.selectEntity(this.entity);
         nextCommandCallback?.(this.entity);


### PR DESCRIPTION
Call `pause()` on the created entity, important when parent is the scene because `play()` has been called because of `scene.isPlaying = true` hack.
We already did it for the entityclone command but not for entitycreate and the undo entityremove.