### PR TITLE
Add paste entity from clipboard button in toolbar (fix #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The [A-Frame editor](https://github.com/c-frame/aframe-editor) is based on the
 
 - Undo/redo feature for all the actions you do in the editor.
 - The '+' button and `n` shortcut add a new child entity to the selected entity.
+- Copy entity HTML to clipboard and paste it in an other scene
 - Better copy a-scene HTML to clipboard with a dedicated button. This replaces
   the aframe-watcher button.
 - Reparent and reorder an entity

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import {
   faPlus,
+  faPaste,
   faPause,
   faPlay,
   // faFloppyDisk,
   faQuestion
 } from '@fortawesome/free-solid-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
-import { getEntityClipboardRepresentation } from '../../lib/entity';
+import {
+  getEntityClipboardRepresentation,
+  parseEntityHTML
+} from '../../lib/entity';
 import CopyToClipboardButton from '../CopyToClipboardButton';
 import ThemeSelector from './ThemeSelector';
 import Events from '../../lib/Events';
@@ -79,6 +83,29 @@ export default class Toolbar extends React.Component {
     });
   }
 
+  pasteEntity = async () => {
+    try {
+      const html = await navigator.clipboard.readText();
+      if (!html.trim()) return;
+
+      const definition = parseEntityHTML(html);
+      if (!definition) return;
+
+      const selected = AFRAME.INSPECTOR.selectedEntity;
+      const defaultParent = AFRAME.INSPECTOR.config.defaultParent.replace(
+        /^#/,
+        ''
+      );
+      if (selected && selected.id !== defaultParent && selected.parentElement) {
+        definition.parentEl = selected.parentElement;
+      }
+
+      AFRAME.INSPECTOR.execute('entitycreate', definition);
+    } catch (error) {
+      console.error('Failed to paste entity from clipboard:', error);
+    }
+  };
+
   /**
    * Try to write changes with aframe-inspector-watcher.
    */
@@ -123,6 +150,13 @@ export default class Toolbar extends React.Component {
             onClick={this.addEntity}
           >
             <AwesomeIcon icon={faPlus} />
+          </a>
+          <a
+            className="button"
+            title="Paste entity from clipboard"
+            onClick={this.pasteEntity}
+          >
+            <AwesomeIcon icon={faPaste} />
           </a>
           <a
             id="playPauseScene"

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -810,6 +810,70 @@ export function elementToObject(element) {
 }
 
 /**
+ * Parse an entity HTML string (from clipboard) into a definition object
+ * compatible with the entitycreate command. Regenerates all IDs.
+ *
+ * @param {string} html Entity HTML string
+ * @returns {EntityObject|null} Entity definition or null if invalid
+ */
+export function parseEntityHTML(html) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const element = doc.body.firstElementChild;
+  if (!element) return null;
+
+  // Check if the root entity's ID already exists in the scene
+  const rootId = element.getAttribute('id');
+  const needsRegenerate = rootId ? !!document.getElementById(rootId) : true;
+
+  function parseElement(el) {
+    const def = {};
+
+    if (el.tagName !== 'A-ENTITY') {
+      def.element = el.tagName.toLowerCase();
+    }
+
+    const originalId = el.getAttribute('id');
+    if (needsRegenerate) {
+      // Regenerate ID using same logic as recursivelyRegenerateId
+      if (originalId) {
+        def.id =
+          originalId.length === 21 ? createUniqueId() : getUniqueId(originalId);
+      } else {
+        def.id = createUniqueId();
+      }
+    } else if (originalId) {
+      def.id = originalId;
+    }
+
+    const components = {};
+    for (const attr of el.attributes) {
+      if (attr.name === 'id') continue;
+      if (NOT_COMPONENTS.includes(attr.name) || attr.name.startsWith('data-')) {
+        def[attr.name] = attr.value;
+        continue;
+      }
+      components[attr.name] = attr.value;
+    }
+    if (Object.keys(components).length > 0) {
+      def.components = components;
+    }
+
+    const children = [];
+    for (const child of el.children) {
+      children.push(parseElement(child));
+    }
+    if (children.length > 0) {
+      def.children = children;
+    }
+
+    return def;
+  }
+
+  return parseElement(element);
+}
+
+/**
  * Converts an entity to a serializable object representation with blacklist filtering.
  * This function prepares an entity for export by applying serialization optimizations,
  * filtering out blacklisted properties, and adding parent relationship metadata.


### PR DESCRIPTION
- Add parseEntityHTML() to parse clipboard HTML into entity definitions
- Add paste button next to add entity button in toolbar
- Preserves original IDs when pasting to a different scene, regenerates when conflict exists