### PR TITLE
Emit sceneplayingtoggle event to disable history when playing

### DIFF
--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -121,6 +121,7 @@ export default class Toolbar extends React.Component {
     if (this.state.isPlaying) {
       AFRAME.scenes[0].pause();
       this.setState({ isPlaying: false });
+      Events.emit('sceneplayingtoggle', false);
       AFRAME.scenes[0].isPlaying = true;
       document.getElementById('aframeInspectorMouseCursor').play();
       return;
@@ -128,6 +129,7 @@ export default class Toolbar extends React.Component {
     AFRAME.scenes[0].isPlaying = false;
     AFRAME.scenes[0].play();
     this.setState({ isPlaying: true });
+    Events.emit('sceneplayingtoggle', true);
   };
 
   openHelpModal = () => {


### PR DESCRIPTION
If forgot to backport that when undo stack was backported from my private editor.
It's used in https://github.com/c-frame/aframe-editor/blob/8b411d44f101ff2672142a43c0658ae00daeb13f/src/lib/history.js#L15-L17

The changes done when the scene is playing should really be reverted when we pause again in my opinion, but that's another big feature to implement.