### PR TITLE
Properly keep old value for entityupdate command for position/rotation/scale change through gizmo

### DIFF
--- a/src/lib/commands/EntityUpdateCommand.js
+++ b/src/lib/commands/EntityUpdateCommand.js
@@ -109,6 +109,14 @@ export class EntityUpdateCommand extends Command {
         );
       }
     }
+
+    // For position/rotation/scale, getAttribute returns the live object3D
+    // values, so the oldValue captured above is wrong for callers that
+    // mutate the object before executing the command (the transform gizmo).
+    // Such callers pass the true pre-change value explicitly.
+    if (payload.oldValue !== undefined) {
+      this.oldValue = payload.oldValue;
+    }
   }
 
   execute(nextCommandCallback) {

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -48,6 +48,13 @@ export function Viewport(inspector) {
     inspector.container
   );
   transformControls.size = 0.75;
+
+  // Pose snapshot taken on the gizmo's mouseDown, BEFORE TransformControls
+  // mutates the object. The undo command can't capture this itself:
+  // getAttribute('position') returns the live object3D values, which are
+  // already post-mutation by the time objectChange fires.
+  let transformPreDragValues = null;
+
   transformControls.addEventListener('objectChange', (evt) => {
     const object = transformControls.object;
     if (object === undefined) {
@@ -78,11 +85,23 @@ export function Viewport(inspector) {
     inspector.execute('entityupdate', {
       component: component,
       entity: transformControls.object.el,
-      value: value
+      value: value,
+      oldValue: transformPreDragValues?.[component]
     });
   });
 
   transformControls.addEventListener('mouseDown', () => {
+    const object = transformControls.object;
+    if (object) {
+      const d = THREE.MathUtils.radToDeg;
+      transformPreDragValues = {
+        position: `${object.position.x} ${object.position.y} ${object.position.z}`,
+        rotation: `${d(object.rotation.x)} ${d(object.rotation.y)} ${d(
+          object.rotation.z
+        )}`,
+        scale: `${object.scale.x} ${object.scale.y} ${object.scale.z}`
+      };
+    }
     controls.enabled = false;
   });
 


### PR DESCRIPTION
Thanks @kfarr for the investigation in https://github.com/3DStreet/3dstreet/pull/1664